### PR TITLE
Modification to Testgrid Annotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ lint:
 
 .PHONY: testgrid
 testgrid:
-	configurator --prow-config prow/config.yaml --prow-job-config prow/cluster/jobs --output-yaml --yaml testgrid/default.yaml --oneshot --validate-config-file
 	configurator --prow-config prow/config.yaml --prow-job-config prow/cluster/jobs --output-yaml --yaml testgrid/default.yaml --oneshot --output testgrid/istio-generated.yaml
 
 include Makefile.common.mk

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -37,6 +37,8 @@ presubmits:
   - name: istio-unit-tests-master
     <<: *job_template
     always_run: true
+    annotations:
+      testgrid-dashboards: istio-presubmits-master
     spec:
       containers:
       - <<: *istio_container
@@ -45,12 +47,12 @@ presubmits:
         - prow/istio-unit-tests.sh
       nodeSelector:
         testing: test-pool
-      annotations:
-        testgrid-dashboards: istio-presubmits-master
 
   - name: istio-lint-master
     <<: *job_template
     always_run: true
+    annotations:
+      testgrid-dashboards: istio-presubmits-master
     spec:
       containers:
       # Lint requires a large amount of memory
@@ -71,12 +73,12 @@ presubmits:
         - prow/istio-lint.sh
       nodeSelector:
         testing: test-pool
-      annotations:
-        testgrid-dashboards: istio-presubmits-master
 
   - name: istio-racetest-master
     <<: *job_template
     always_run: true
+    annotations:
+      testgrid-dashboards: istio-presubmits-master
     spec:
       containers:
       - <<: *istio_container
@@ -85,12 +87,12 @@ presubmits:
         - prow/racetest.sh
       nodeSelector:
         testing: test-pool
-      annotations:
-        testgrid-dashboards: istio-presubmits-master
 
   - name: istio-shellcheck-master
     <<: *job_template
     always_run: true
+    annotations:
+      testgrid-dashboards: istio-presubmits-master
     spec:
       containers:
       - <<: *istio_container
@@ -99,8 +101,6 @@ presubmits:
         - prow/shellcheck.sh
       nodeSelector:
         testing: test-pool
-      annotations:
-        testgrid-dashboards: istio-presubmits-master
 
   - name: istio-codecov-master
     <<: *job_template
@@ -113,8 +113,8 @@ presubmits:
         - prow/codecov.sh
       nodeSelector:
         testing: test-pool
-      annotations:
-        testgrid-dashboards: istio-presubmits-master
+    annotations:
+      testgrid-dashboards: istio-presubmits-master
 
   - name: integ-framework-local-presubmit-tests-master
     <<: *job_template

--- a/testgrid/istio-generated.yaml
+++ b/testgrid/istio-generated.yaml
@@ -28,7 +28,23 @@ default_test_group:
   tests_name_policy: 2
   use_kubernetes_client: true
 dashboards:
-- name: istio-presubmits-master
+- dashboard_tab:
+  - description: istio-unit-tests-master
+    name: istio-unit-tests-master
+    test_group_name: istio-unit-tests-master
+  - description: istio-lint-master
+    name: istio-lint-master
+    test_group_name: istio-lint-master
+  - description: istio-racetest-master
+    name: istio-racetest-master
+    test_group_name: istio-racetest-master
+  - description: istio-shellcheck-master
+    name: istio-shellcheck-master
+    test_group_name: istio-shellcheck-master
+  - description: istio-codecov-master
+    name: istio-codecov-master
+    test_group_name: istio-codecov-master
+  name: istio-presubmits-master
 - name: istio-postsubmits-master
 test_groups:
 - gcs_prefix: istio-prow/logs/test-infra-cleanup-GKE
@@ -49,16 +65,6 @@ test_groups:
   name: release-trigger-daily-build-release-1.2
 - gcs_prefix: istio-prow/logs/monitoring-verify-gcsweb
   name: monitoring-verify-gcsweb
-- gcs_prefix: istio-prow/logs/proxy-postsubmit
-  name: proxy-postsubmit
-- gcs_prefix: istio-prow/logs/api-postsubmit
-  name: api-postsubmit
-- gcs_prefix: istio-prow/logs/release-daily
-  name: release-daily
-- gcs_prefix: istio-prow/logs/perf-for-daily-release
-  name: perf-for-daily-release
-- gcs_prefix: istio-prow/logs/release-monthly
-  name: release-monthly
 - gcs_prefix: istio-prow/logs/integ-framework-local-postsubmit-tests
   name: integ-framework-local-postsubmit-tests
 - gcs_prefix: istio-prow/logs/integ-galley-local-postsubmit-tests
@@ -304,4 +310,23 @@ test_groups:
   num_columns_recent: 20
 - gcs_prefix: istio-prow/logs/istio_auth_sds_e2e-release-1.2
   name: istio_auth_sds_e2e-release-1.2
+  num_columns_recent: 20
+- gcs_prefix: istio-prow/logs/api-postsubmit
+  name: api-postsubmit
+- gcs_prefix: istio-prow/logs/release-daily
+  name: release-daily
+- gcs_prefix: istio-prow/logs/perf-for-daily-release
+  name: perf-for-daily-release
+- gcs_prefix: istio-prow/logs/release-monthly
+  name: release-monthly
+- gcs_prefix: istio-prow/logs/proxy-postsubmit
+  name: proxy-postsubmit
+- gcs_prefix: istio-prow/pr-logs/directory/istio-lint-master
+  name: istio-lint-master
+  num_columns_recent: 20
+- gcs_prefix: istio-prow/pr-logs/directory/istio-racetest-master
+  name: istio-racetest-master
+  num_columns_recent: 20
+- gcs_prefix: istio-prow/pr-logs/directory/istio-shellcheck-master
+  name: istio-shellcheck-master
   num_columns_recent: 20


### PR DESCRIPTION
Two notes:
1. Configurator validates as part of running, so there isn't a need to "pre-validate" it. That flag is more like a "dry-run", if validation is the only thing you're looking for.
2. The indentations were too far in. Annotations are part of the prow job, not part of the prow job's spec. I've moved them to make them a bit more readable; similar to the recommendation [here](https://github.com/kubernetes/test-infra/issues/13413)